### PR TITLE
Changes to make querydsl-elasticsearch work with latest elasticsearch

### DIFF
--- a/querydsl-elasticsearch/pom.xml
+++ b/querydsl-elasticsearch/pom.xml
@@ -22,8 +22,8 @@
   </scm>
 
   <properties>
-    <elasticsearch.version>1.3.4</elasticsearch.version>
-    <jackson.version>2.4.2</jackson.version>
+    <elasticsearch.version>2.1.0</elasticsearch.version>
+    <jackson.version>2.6.3</jackson.version>
     <osgi.import.package>
       org.elasticsearch.*;version="0.0.0",
       com.fasterxml.jackson.core.*;version="0.0.0",

--- a/querydsl-elasticsearch/src/main/java/com/querydsl/elasticsearch/ElasticsearchSerializer.java
+++ b/querydsl-elasticsearch/src/main/java/com/querydsl/elasticsearch/ElasticsearchSerializer.java
@@ -93,12 +93,12 @@ public class ElasticsearchSerializer implements Visitor<Object, BoolQueryBuilder
             } else {
                 // Currently all queries are made with ignore case sensitive
                 // Because the query to get exact value have to be run on a not_analyzed field
-                return QueryBuilders.queryString(value).field(asDBKey(expr, 0));
+                return QueryBuilders.queryStringQuery(value).field(asDBKey(expr, 0));
             }
 
         } else if (op == Ops.EQ_IGNORE_CASE) {
             String value = StringUtils.toString(asDBValue(expr, 1));
-            return QueryBuilders.queryString(value).field(asDBKey(expr, 0));
+            return QueryBuilders.queryStringQuery(value).field(asDBKey(expr, 0));
 
         } else if (op == Ops.NE) {
             // Decompose the query as NOT and EQ query
@@ -112,7 +112,7 @@ public class ElasticsearchSerializer implements Visitor<Object, BoolQueryBuilder
                     context);
 
         } else if (op == Ops.STRING_IS_EMPTY) {
-            return QueryBuilders.queryString("").field(asDBKey(expr, 0));
+            return QueryBuilders.queryStringQuery("").field(asDBKey(expr, 0));
 
         } else if (op == Ops.AND || op == Ops.OR) {
             Operation<?> left = (Operation<?>) expr.getArg(0);
@@ -156,7 +156,7 @@ public class ElasticsearchSerializer implements Visitor<Object, BoolQueryBuilder
                 if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
                     Collection<?> values = (Collection<?>) ((Constant<?>) expr.getArg(constIndex)).getConstant();
                     for (Object value : values) {
-                        boolQuery.should(QueryBuilders.queryString(StringUtils.toString(value)).field(key));
+                        boolQuery.should(QueryBuilders.queryStringQuery(StringUtils.toString(value)).field(key));
                     }
                     return boolQuery;
 
@@ -193,24 +193,28 @@ public class ElasticsearchSerializer implements Visitor<Object, BoolQueryBuilder
         } else if (op == Ops.STARTS_WITH) {
             // Currently all queries are made with ignore case sensitive
             String value = StringUtils.toString(asDBValue(expr, 1));
-            return QueryBuilders.queryString(value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+            return QueryBuilders.queryStringQuery(value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
 
         } else if (op == Ops.STARTS_WITH_IC) {
             String value = StringUtils.toString(asDBValue(expr, 1));
-            return QueryBuilders.queryString(value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+            return QueryBuilders.queryStringQuery(value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
 
         } else if (op == Ops.ENDS_WITH) {
             // Currently all queries are made with ignore case sensitive
             String value = StringUtils.toString(asDBValue(expr, 1));
-            return QueryBuilders.queryString("*" + value).field(asDBKey(expr, 0)).analyzeWildcard(true);
+            return QueryBuilders.queryStringQuery("*" + value).field(asDBKey(expr, 0)).analyzeWildcard(true);
 
         } else if (op == Ops.ENDS_WITH_IC) {
             String value = StringUtils.toString(asDBValue(expr, 1));
-            return QueryBuilders.queryString("*" + value).field(asDBKey(expr, 0)).analyzeWildcard(true);
+            return QueryBuilders.queryStringQuery("*" + value).field(asDBKey(expr, 0)).analyzeWildcard(true);
 
         } else if (op == Ops.STRING_CONTAINS) {
             String value = StringUtils.toString(asDBValue(expr, 1));
-            return QueryBuilders.queryString("*" + value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+            return QueryBuilders.queryStringQuery("*" + value + "*").field(asDBKey(expr, 0)).analyzeWildcard(true);
+
+        } else if (op == Ops.STRING_CONTAINS_IC) {
+            String value = StringUtils.toString(asDBValue(expr, 1));
+            return QueryBuilders.queryStringQuery("*" + value + "*").field(asDBKey(expr, 0)).analyzer("standard").analyzeWildcard(true);
 
         } else if (op == Ops.NOT) {
             // Handle the not's child

--- a/querydsl-elasticsearch/src/test/java/com/querydsl/elasticsearch/ElasticsearchQueryTest.java
+++ b/querydsl-elasticsearch/src/test/java/com/querydsl/elasticsearch/ElasticsearchQueryTest.java
@@ -3,6 +3,7 @@ package com.querydsl.elasticsearch;
 import static java.util.Arrays.asList;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 import static org.elasticsearch.client.Requests.refreshRequest;
 import static org.junit.Assert.*;
 
@@ -16,7 +17,7 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
-import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.junit.Before;
@@ -52,7 +53,9 @@ public class ElasticsearchQueryTest {
 
     @BeforeClass
     public static void beforeClass() {
-        ImmutableSettings.Builder settings = ImmutableSettings.builder().put("path.data", ElasticsearchQueryTest.class.getResource("").getPath());
+        String path  = ElasticsearchQueryTest.class.getResource("").getPath();
+        path = System.getProperty( "os.name" ).contains( "indow" ) ? path.substring(1) : path;
+        Settings.Builder settings = Settings.builder().put("path.home",path);
         Node node = NodeBuilder.nodeBuilder().local(true).settings(settings).node();
         client = node.client();
 
@@ -115,6 +118,16 @@ public class ElasticsearchQueryTest {
     @Test
     public void NotContains() {
         //assertQuery(user.friends.contains(u1).not(), u1);
+    }
+
+    @Test
+    public void Contains_Ignore_Case() {
+        assertTrue(where(user.firstName.containsIgnoreCase("akk")).fetchCount() > 0);
+    }
+
+    @Test
+    public void Contains_Ignore_Case_2() {
+        assertFalse(where(user.firstName.containsIgnoreCase("xyzzz")).fetchCount() > 0);
     }
 
     @Test
@@ -295,7 +308,7 @@ public class ElasticsearchQueryTest {
     }
 
     public void refresh(String indexName, boolean waitForOperation) {
-        client.admin().indices().refresh(refreshRequest(indexName).force(waitForOperation)).actionGet();
+        client.admin().indices().refresh(refreshRequest(indexName)).actionGet();
     }
 
 }

--- a/querydsl-elasticsearch/src/test/java/com/querydsl/elasticsearch/ElasticsearchQueryTest.java
+++ b/querydsl-elasticsearch/src/test/java/com/querydsl/elasticsearch/ElasticsearchQueryTest.java
@@ -54,7 +54,7 @@ public class ElasticsearchQueryTest {
     @BeforeClass
     public static void beforeClass() {
         String path  = ElasticsearchQueryTest.class.getResource("").getPath();
-        path = System.getProperty( "os.name" ).contains( "indow" ) ? path.substring(1) : path;
+        path = System.getProperty("os.name").contains("indow") ? path.substring(1) : path;
         Settings.Builder settings = Settings.builder().put("path.home",path);
         Node node = NodeBuilder.nodeBuilder().local(true).settings(settings).node();
         client = node.client();

--- a/querydsl-elasticsearch/src/test/java/com/querydsl/elasticsearch/ElasticsearchSerializerTest.java
+++ b/querydsl-elasticsearch/src/test/java/com/querydsl/elasticsearch/ElasticsearchSerializerTest.java
@@ -257,7 +257,7 @@ public class ElasticsearchSerializerTest {
     }
 
     public static QueryBuilder eq(String key, Object value) {
-        return QueryBuilders.queryString(StringUtils.toString(value)).field(key);
+        return QueryBuilders.queryStringQuery(StringUtils.toString(value)).field(key);
     }
 
     public static QueryBuilder in(String key, Iterable<?> values) {


### PR DESCRIPTION
This change contains
 - Fixes to make querydsl-elasticsearch to work with the latest elasticsearch 2.x
 - Added the String Contains Ignorecase criteria support

Except for the Package verification test case , other test cases passed.

Let me know if you need any other changes to this fix.